### PR TITLE
Add Shields.io badges to the README file 📇

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![IssuesClosed](https://img.shields.io/github/issues-closed/artkirienko/ci_and_crosscompile.svg?style=flat-square)](https://github.com/artkirienko/ci_and_crosscompile/issues)
 [![PullRequestsClosed](https://img.shields.io/github/issues-pr-closed/artkirienko/ci_and_crosscompile.svg?style=flat-square)](https://github.com/artkirienko/ci_and_crosscompile/pulls)
 [![HitCount](http://hits.dwyl.io/artkirienko/ci_and_crosscompile.svg)](http://hits.dwyl.io/artkirienko/ci_and_crosscompile)
+[![Tag](https://img.shields.io/github/tag/artkirienko/ci_and_crosscompile.svg?style=flat-square)](https://github.com/artkirienko/ci_and_crosscompile/releases)
 
 # CI and Cross-compile
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://img.shields.io/travis/artkirienko/ci_and_crosscompile/master.svg?style=flat-square)](https://travis-ci.org/artkirienko/ci_and_crosscompile)
-[![CircleCI](https://circleci.com/gh/artkirienko/ci_and_crosscompile/tree/master.svg?style=shield)](https://circleci.com/gh/artkirienko/ci_and_crosscompile/tree/master)
+[![CircleCI](https://img.shields.io/circleci/project/github/artkirienko/ci_and_crosscompile/master.svg?style=flat-square)](https://circleci.com/gh/artkirienko/ci_and_crosscompile/tree/master)
 [![HitCount](http://hits.dwyl.io/artkirienko/ci_and_crosscompile.svg)](http://hits.dwyl.io/artkirienko/ci_and_crosscompile)
 
 # CI and Cross-compile

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/artkirienko/ci_and_crosscompile.svg?branch=master)](https://travis-ci.org/artkirienko/ci_and_crosscompile)
+[![Build Status](https://img.shields.io/travis/artkirienko/ci_and_crosscompile/master.svg?style=flat-square)](https://travis-ci.org/artkirienko/ci_and_crosscompile)
 [![CircleCI](https://circleci.com/gh/artkirienko/ci_and_crosscompile/tree/master.svg?style=shield)](https://circleci.com/gh/artkirienko/ci_and_crosscompile/tree/master)
 [![HitCount](http://hits.dwyl.io/artkirienko/ci_and_crosscompile.svg)](http://hits.dwyl.io/artkirienko/ci_and_crosscompile)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://img.shields.io/travis/artkirienko/ci_and_crosscompile/master.svg?style=flat-square)](https://travis-ci.org/artkirienko/ci_and_crosscompile)
 [![CircleCI](https://img.shields.io/circleci/project/github/artkirienko/ci_and_crosscompile/master.svg?style=flat-square)](https://circleci.com/gh/artkirienko/ci_and_crosscompile/tree/master)
 [![IssuesClosed](https://img.shields.io/github/issues-closed/artkirienko/ci_and_crosscompile.svg?style=flat-square)](https://github.com/artkirienko/ci_and_crosscompile/issues)
+[![PullRequestsClosed](https://img.shields.io/github/issues-pr-closed/artkirienko/ci_and_crosscompile.svg?style=flat-square)](https://github.com/artkirienko/ci_and_crosscompile/pulls)
 [![HitCount](http://hits.dwyl.io/artkirienko/ci_and_crosscompile.svg)](http://hits.dwyl.io/artkirienko/ci_and_crosscompile)
 
 # CI and Cross-compile

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://img.shields.io/travis/artkirienko/ci_and_crosscompile/master.svg?style=flat-square)](https://travis-ci.org/artkirienko/ci_and_crosscompile)
 [![CircleCI](https://img.shields.io/circleci/project/github/artkirienko/ci_and_crosscompile/master.svg?style=flat-square)](https://circleci.com/gh/artkirienko/ci_and_crosscompile/tree/master)
+[![IssuesClosed](https://img.shields.io/github/issues-closed/artkirienko/ci_and_crosscompile.svg?style=flat-square)](https://github.com/artkirienko/ci_and_crosscompile/issues)
 [![HitCount](http://hits.dwyl.io/artkirienko/ci_and_crosscompile.svg)](http://hits.dwyl.io/artkirienko/ci_and_crosscompile)
 
 # CI and Cross-compile

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![IssuesClosed](https://img.shields.io/github/issues-closed/artkirienko/ci_and_crosscompile.svg?style=flat-square)](https://github.com/artkirienko/ci_and_crosscompile/issues)
 [![PullRequestsClosed](https://img.shields.io/github/issues-pr-closed/artkirienko/ci_and_crosscompile.svg?style=flat-square)](https://github.com/artkirienko/ci_and_crosscompile/pulls)
 [![HitCount](http://hits.dwyl.io/artkirienko/ci_and_crosscompile.svg)](http://hits.dwyl.io/artkirienko/ci_and_crosscompile)
+[![LicenseMIT](https://img.shields.io/github/license/artkirienko/ci_and_crosscompile.svg?style=flat-square)](LICENSE)
 [![Tag](https://img.shields.io/github/tag/artkirienko/ci_and_crosscompile.svg?style=flat-square)](https://github.com/artkirienko/ci_and_crosscompile/releases)
 
 # CI and Cross-compile


### PR DESCRIPTION
## Shields.io: Quality metadata badges for open source projects

https://shields.io/
> Fast and scalable informational images as badges for GitHub, Travis CI, Jenkins, WordPress and many more services.
> 
> Pixel-perfect, Retina-ready, Fast, Consistent, Hackable, No tracking

